### PR TITLE
Shorten file operation labels in Ukrainian translation

### DIFF
--- a/BTPanel/static/vite/lang/uk/file.json
+++ b/BTPanel/static/vite/lang/uk/file.json
@@ -130,15 +130,17 @@
 				"untitledFile": "новий файл"
 			}
 		},
-		"fileOperation": {
-			"cut": "Виріз.",
-			"rename": "Переім.",
-                        "permission": "Права",
-                        "PMSN": "Pmsn",
-			"compress": "Архів",
-			"open": "Відкрити",
-			"decompress": "Розпак."
-		},
+                "fileOperation": {
+                        "open": "Відкр.",
+                        "copy": "Копія",
+                        "cut": "Виріз.",
+                        "rename": "Переім.",
+                        "permission": "Дозвіл",
+                        "PMSN": "Права",
+                        "compress": "Архів",
+                        "delete": "Видал.",
+                        "decompress": "Розпак."
+                },
 		"contextMenu": {
 			"createCompression": "Стиснути",
 			"formatConversion": "Конвертація формату",


### PR DESCRIPTION
## Summary
- shorten file operation labels for a compact toolbar

## Testing
- `python -m json.tool BTPanel/static/vite/lang/uk/file.json`
- `bash ua_language_pack.sh` *(fails: no write access to /www/server/panel/)*

------
https://chatgpt.com/codex/tasks/task_e_689ae82690ec8325b1861637becaa93e